### PR TITLE
make the throttle function not keep the event loop active

### DIFF
--- a/src/useThrottle.ts
+++ b/src/useThrottle.ts
@@ -33,7 +33,7 @@ function useThrottle(resource: any, interval: number) {
                     jobs.delete(key);
                 }
             });
-        }, gcInterval);
+        }, gcInterval).unref();
 
         if (typeof process === "object" && getGlobal("Deno") === void 0) {
             process.on("beforeExit", () => clearInterval(useThrottle.gcTimer));

--- a/src/useThrottle.ts
+++ b/src/useThrottle.ts
@@ -33,7 +33,11 @@ function useThrottle(resource: any, interval: number) {
                     jobs.delete(key);
                 }
             });
-        }, gcInterval).unref();
+        }, gcInterval);
+        
+        if (typeof useThrottle.gcTimer.unref === "function") {
+            useThrottle.gcTimer.unref();
+        }
 
         if (typeof process === "object" && getGlobal("Deno") === void 0) {
             process.on("beforeExit", () => clearInterval(useThrottle.gcTimer));


### PR DESCRIPTION
If we do not unref the timeout then it will keep the event loop active, which means the process will never exit due to inactivity. This is an issue when running a test suite with a framework such as Mocha because Mocha will not exit if the event loop still has activity.

When `unref()` is called, the active Timeout object will not require the Node.js event loop to remain active. If there is no other activity keeping the event loop running, the process may exit.

Docs: https://nodejs.org/api/timers.html#timers_timeout_unref